### PR TITLE
Add accessibility to the glitch tag

### DIFF
--- a/game/glitch_tag.rpy
+++ b/game/glitch_tag.rpy
@@ -82,6 +82,9 @@ init python:
             if kind == renpy.TEXT_TEXT:
                 char_disp = GlitchText(my_style.apply_style(text), argument)
                 new_list.append((renpy.TEXT_DISPLAYABLE, char_disp))
+                new_list.append((renpy.TEXT_TAG, "alt"))
+                new_list.append((renpy.TEXT_TEXT, text))
+                new_list.append((renpy.TEXT_TAG, "/alt"))
             elif kind == renpy.TEXT_TAG:
                 if text.find("image") != -1:
                     tag, _, value = text.partition("=")


### PR DESCRIPTION
Because these tags replace regular text, they can break self-voicing (and maybe other a11y features). This is a fix for the `glitch` tag, making it add `alt` text automatically. You can test it by hitting "V" to turn on self-voicing, then hovering over any text.

I'd love to see the other tags get alt text added, but this is the only one I'm using right now, so it's the only one I've fixed on my own.