### PR TITLE
Fix GlitchText fatal exception with self-voicing

### DIFF
--- a/game/glitch_tag.rpy
+++ b/game/glitch_tag.rpy
@@ -33,7 +33,7 @@
 
 
 init python:
-    class GlitchText(renpy.Displayable):
+    class GlitchText(renpy.Displayable,str):
         def __init__(self, child, amount, **kwargs):
             super(GlitchText, self).__init__(**kwargs)
             if isinstance(child, (str, unicode)):
@@ -41,6 +41,10 @@ init python:
             else:
                 self.child = child
             self.amount = amount
+
+        def __new__(cls, child, amount, **kwargs):
+            if isinstance(child, (str, unicode)):
+                return str.__new__(cls, child)
 
         def render(self, width, height, st, at):
             child_render = renpy.render(self.child, width, height, st, at)


### PR DESCRIPTION
Update `GlitchText` to extend the `str` class so that Ren'py self-voicing does not throw a fatal exception on dialogue that uses the `{glitch}` tag.

This is an alternative approach to that proposed in #3 and seems to work more reliably.